### PR TITLE
defer closing channels & recover from failures to read req + resps

### DIFF
--- a/src/bidirectional_stream.go
+++ b/src/bidirectional_stream.go
@@ -112,8 +112,22 @@ func (s *bidirectionalStream) run() {
 
 	wg.Wait()
 
-	capturedRequest := <-requestChannel
-	capturedResponse := <-responseChannel
+	var capturedRequest *http.Request
+	var capturedResponse *http.Response
+
+	select {
+	case capturedRequest = <-requestChannel:
+	default:
+		slog.Warn("No request captured")
+		return
+	}
+
+	select {
+	case capturedResponse = <-responseChannel:
+	default:
+		slog.Warn("No response captured")
+		return
+	}
 
 	*s.requestAndResponseChannel <- httpRequestAndResponse{
 		request:  capturedRequest,

--- a/src/bidirectional_stream.go
+++ b/src/bidirectional_stream.go
@@ -53,6 +53,8 @@ func (s *bidirectionalStream) run() {
 
 	requestChannel := make(chan *http.Request, 1)
 	responseChannel := make(chan *http.Response, 1)
+	defer close(requestChannel)
+	defer close(responseChannel)
 
 	go func() {
 		reader := bufio.NewReader(&s.clientToServer)
@@ -101,8 +103,6 @@ func (s *bidirectionalStream) run() {
 
 	capturedRequest := <-requestChannel
 	capturedResponse := <-responseChannel
-	close(requestChannel)
-	close(responseChannel)
 
 	*s.requestAndResponseChannel <- httpRequestAndResponse{
 		request:  capturedRequest,


### PR DESCRIPTION
 - Defers closing channels used for receiving captured request and response
 - Implements recovering from failures when reading requests and responses