### PR TITLE
return each tcpassembly.Stream from New exactly once

### DIFF
--- a/src/bidirectional_stream.go
+++ b/src/bidirectional_stream.go
@@ -24,7 +24,7 @@ func (f *bidirectionalStreamFactory) New(netFlow, tcpFlow gopacket.Flow) tcpasse
 	key := netFlow.FastHash() ^ tcpFlow.FastHash()
 
 	// The second time we see the same connection, it will be from the server to the client
-	if conn, ok := f.conns.Load(fmt.Sprint(key)); ok {
+	if conn, ok := f.conns.LoadAndDelete(fmt.Sprint(key)); ok {
 		return &conn.(*bidirectionalStream).serverToClient
 	}
 


### PR DESCRIPTION
This should ensure each tcpassembly.Stream is returned from New exactly once