### PR TITLE
Fix nil pointer dereference when not in dev mode

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -128,10 +128,7 @@ func main() {
 				"Content-Length", strconv.Itoa(int(requestAndResponse.request.ContentLength)),
 			)
 			requestAndResponse.request.Header.Set("Host", requestAndResponse.request.Host)
-			var responseRecorder *httptest.ResponseRecorder
-			if devEnabled {
-				responseRecorder = httptest.NewRecorder()
-			}
+			responseRecorder := httptest.NewRecorder()
 			firetailMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(requestAndResponse.response.StatusCode)
 				for key, values := range requestAndResponse.response.Header {


### PR DESCRIPTION
can't pass nil to middleware - always need a response recorder here